### PR TITLE
Fix crash in InteractableSelector when running "Standalone Game" from editor

### DIFF
--- a/Plugins/OculusHandTools/Source/OculusInteractable/Private/InteractableSelector.cpp
+++ b/Plugins/OculusHandTools/Source/OculusInteractable/Private/InteractableSelector.cpp
@@ -36,12 +36,12 @@ AInteractableSelector::AInteractableSelector()
 
 #if WITH_EDITORONLY_DATA
 	ArrowComponent = CreateEditorOnlyDefaultSubobject<UArrowComponent>(TEXT("Arrow"));
-	ArrowComponent->SetupAttachment(RootComponent);
 
 	if (!IsRunningCommandlet())
 	{
 		if (ArrowComponent)
 		{
+			ArrowComponent->SetupAttachment(RootComponent);
 			ArrowComponent->ArrowColor = FColor(128, 92, 207);
 			ArrowComponent->ArrowSize = 1.0f;
 			ArrowComponent->bIsScreenSizeScaled = true;


### PR DESCRIPTION
Fix crash when running "Standalone Game" from editor and CreateEditorOnlyDefaultSubobject is used.

When running via editor's "Standalone Game" launcher, WITH_EDITORONLY_DATA is 1, but GIsEditor will be false (so no SubObject will be created). Thus ArrowComponent will be nullptr, yet we currently try to SetupAttachment without checking.